### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ preauthorizePermission method (At the moment this method is not working).
 <img src="http://i.imgur.com/AUYL7dK.png" alt="WebRTC on the Chrome WebView Example" />
 </p>
 
-##TEXT_AUTOSIZING
+## TEXT_AUTOSIZING
 
 From KitKat and above, there will no longer be support for [SINGLE_COLUMN or NARROW_COLUMN layout algorithms](http://developer.android.com/reference/android/webkit/WebSettings.LayoutAlgorithm.html).
 
@@ -41,7 +41,7 @@ However a new layout algorithm [TEXT_AUTOSIZING](http://developer.android.com/re
 <img src="http://i.imgur.com/03c0isb.png" alt="Image Show off TEXT_AUTOSIZING" />
 </p>
 
-##Touch Events in the WebView
+## Touch Events in the WebView
 
 In the older version of the WebView developers didn't need to implement the *touchcancel* event, although it's good practice to do so.
 
@@ -53,7 +53,7 @@ The *web-touch-example* contains a simple app which uses touch to move an elemen
 <img src="http://i.imgur.com/ffz4gkV.png" alt="Image of WebView Touch Example" />
 </p>
 
-##JS Interface in the WebView
+## JS Interface in the WebView
 
 This example demonstrates the following:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
